### PR TITLE
Add possibility to use custom launch ID.

### DIFF
--- a/src/main/java/com/epam/reportportal/service/ReportPortal.java
+++ b/src/main/java/com/epam/reportportal/service/ReportPortal.java
@@ -3,7 +3,7 @@
  *
  *
  * This file is part of EPAM Report Portal.
- * https://github.com/reportportal/client
+ * https://github.com/reportportal/client-java-core
  *
  * Report Portal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,6 +59,13 @@ public abstract class ReportPortal {
 
         ReportPortalImpl service = new ReportPortalImpl(rpClient, parameters);
         service.startLaunch(rq);
+        return service;
+    }
+
+    public static ReportPortal reuseLaunch(ReportPortalClient rpClient, ListenerParameters parameters,
+            String currentLaunchId) {
+        ReportPortalImpl service = new ReportPortalImpl(rpClient, parameters);
+        service.reuseLaunch(currentLaunchId);
         return service;
     }
 
@@ -147,9 +154,9 @@ public abstract class ReportPortal {
                     SaveLogRQ.File f = new SaveLogRQ.File();
                     f.setContentType(detect(file));
                     f.setContent(toByteArray(file));
-					
+
                     f.setName(UUID.randomUUID().toString());
-                    rq.setFile(f);					
+                    rq.setFile(f);
                 } catch (IOException e) {
                     // seems like there is some problem. Do not report an file
                     LOGGER.error("Cannot send file to ReportPortal", e);

--- a/src/main/java/com/epam/reportportal/service/ReportPortalImpl.java
+++ b/src/main/java/com/epam/reportportal/service/ReportPortalImpl.java
@@ -96,6 +96,19 @@ public class ReportPortalImpl extends ReportPortal {
         return launch;
     }
 
+    public Maybe<String> reuseLaunch(final String currentLaunchId) {
+        this.launch = Maybe.create(new MaybeOnSubscribe<String>()
+        {
+            @Override
+            public void subscribe(MaybeEmitter<String> e) throws Exception
+            {
+                e.onSuccess(currentLaunchId);
+            }
+        });
+        this.launch.subscribeOn(Schedulers.io()).subscribe();
+        return launch;
+    }
+
     /**
      * Finishes launch in ReportPortal. Blocks until all items are reported correctly
      *


### PR DESCRIPTION
Could be used with following scenarios:
1. Several regression suites are launched in different time. All of them reports to the same single launch on Report Portal.
2. Performance testing - parallel regression suites run from several computers that report to the same single Report Portal launch.