### PR TITLE
Changing Content_Type to lower case when accessing http response header

### DIFF
--- a/src/main/java/com/epam/reportportal/service/ReportPortalErrorHandler.java
+++ b/src/main/java/com/epam/reportportal/service/ReportPortalErrorHandler.java
@@ -124,7 +124,7 @@ public class ReportPortalErrorHandler extends DefaultErrorHandler {
 
 		boolean result = true;
 
-		Collection<String> contentTypes = rs.getHeaders().get(HttpHeaders.CONTENT_TYPE);
+		Collection<String> contentTypes = rs.getHeaders().get(HttpHeaders.CONTENT_TYPE.toLowerCase());
 
 		for (String contentType : contentTypes) {
 


### PR DESCRIPTION
HTTP field names are case insensitive, so the case should not matter
Fix for this issue:
https://github.com/reportportal/client-java/issues/28#issue-435878217