### PR TITLE
EPMRPP-45159 || Make the CONTEXT_THREAD_LOCAL Inheritable

### DIFF
--- a/src/main/java/com/epam/reportportal/service/LoggingContext.java
+++ b/src/main/java/com/epam/reportportal/service/LoggingContext.java
@@ -61,7 +61,7 @@ public class LoggingContext {
 	/* default back-pressure buffer size */
 	public static final int DEFAULT_BUFFER_SIZE = 10;
 
-	static final ThreadLocal<Deque<LoggingContext>> CONTEXT_THREAD_LOCAL = new ThreadLocal<Deque<LoggingContext>>() {
+	static final ThreadLocal<Deque<LoggingContext>> CONTEXT_THREAD_LOCAL = new InheritableThreadLocal<Deque<LoggingContext>>() {
 		@Override
 		protected Deque<LoggingContext> initialValue() {
 			return new ArrayDeque<LoggingContext>();


### PR DESCRIPTION
This change allows threads initialized inside some test method context to log properly into ReportPortal by inheriting the existing logging context for new threads.

This solves an issue with TestNG annotated methods with timeout like `@Test(timeOut=30000)` not reporting logs, and also allows tests to use threads inside a test methods without worrying of logs being not reported.

Change has been tested locally and doesn't seem to break for TestNG agent, but probably need to consider carefully if this doesn't have additional side effects.