### PR TITLE
Fix NPE in StepReporter

### DIFF
--- a/src/main/java/com/epam/reportportal/service/step/DefaultStepReporter.java
+++ b/src/main/java/com/epam/reportportal/service/step/DefaultStepReporter.java
@@ -83,7 +83,10 @@ public class DefaultStepReporter implements StepReporter {
 
 	@Override
 	public boolean isFailed(final Maybe<String> parentId) {
-		return parentFailures.contains(parentId);
+		if (parentId != null) {
+			return parentFailures.contains(parentId);
+		}
+		return false;
 	}
 
 	protected void sendStep(final ItemStatus status, final String name, final Runnable actions) {


### PR DESCRIPTION
https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ConcurrentHashMap.html#contains(java.lang.Object)

Original error:
Caused by: java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964)
	at java.util.Collections$SetFromMap.contains(Collections.java:5459)
	at com.epam.reportportal.service.step.StepReporter.isFailed(StepReporter.java:115)
	at com.epam.reportportal.testng.TestNGService.finishTestMethod(TestNGService.java:483)
	at com.epam.reportportal.testng.BaseTestNGListener.onConfigurationFailure(BaseTestNGListener.java:109)
	at org.testng.internal.TestListenerHelper.runPostConfigurationListeners(TestListenerHelper.java:40)
	at org.testng.internal.Invoker.runConfigurationListeners(Invoker.java:1384)
	at org.testng.internal.Invoker.handleConfigurationFailure(Invoker.java:271)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:227)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:142)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:401)
	at org.testng.SuiteRunner.run(SuiteRunner.java:364)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:84)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1208)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1137)
	at org.testng.TestNG.runSuites(TestNG.java:1049)
	at org.testng.TestNG.run(TestNG.java:1017)