### PR TITLE
Be able to append already existing launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ rp.description=My awesome launch
 rp.attributes=key:value;value
 rp.rerun=true
 rp.rerun.of=ae586912-841c-48de-9391-50720c35dd5a
+rp.append=true
+rp.append.of=ae586912-841c-48de-9391-50720c35dd5a
 rp.convertimage=true
 rp.mode=DEFAULT
 rp.skipped.issue=true
@@ -61,6 +63,8 @@ User should provide next parameters to agent.
 |rp.reporting.callback   | Boolean  |Enables [callback reporting](https://github.com/reportportal/client-java/wiki/Callback-reporting-usefulness). Available values - `true` or `false`(by default). Supported only in 5+ vesion |No |
 |rp.rerun                | Boolean  |Enables [rerun mode](https://github.com/reportportal/documentation/blob/master/src/md/src/DevGuides/rerun.md). Available values - `true` or `false`(by default). Supported only in 5+ version | No |
 |rp.rerun.of             | String   |Specifies UUID of launch that has to be reruned |No |
+|rp.append                | Boolean  |Enables [append mode](https://github.com/reportportal/documentation/blob/master/src/md/src/DevGuides/append.md). Available values - `true` or `false`(by default). Supported only in 5+ version | No |
+|rp.append.of             | String   |Specifies UUID of launch that has to be appended |No |
 |rp.convertimage         | Boolean  |Colored log images can be converted to grayscale for reducing image size. Values: ‘true’ – will be converted. Any other value means ‘false’. |No |
 |rp.mode                 | Enum     |ReportPortal provides possibility to specify visibility of executing launch. Currently two modes are supported: DEFAULT - all users from project can see this launch; DEBUG - all users except of Customer role can see this launch (in debug sub tab). Note: for all java based clients (TestNG, Junit) mode will be set automatically to "DEFAULT" if it is not specified. |No |
 |rp.skipped.issue        | Boolean  |ReportPortal provides feature to mark skipped tests as not 'To Investigate' items on WS side. Parameter could be equal boolean values: <li>`true` - skipped tests considered as issues and will be marked as 'To Investigate' on Report Portal. <li>`false` - skipped tests will not be marked as 'To Investigate' on application. |No |

--- a/src/main/java/com/epam/reportportal/listeners/ListenerParameters.java
+++ b/src/main/java/com/epam/reportportal/listeners/ListenerParameters.java
@@ -87,6 +87,8 @@ public class ListenerParameters implements Cloneable {
 	private String keystorePassword;
 	private boolean rerun;
 	private String rerunOf;
+	private boolean append;
+	private String appendTo;
 	private boolean asyncReporting;
 	private boolean callbackReportingEnabled;
 	private Integer ioPoolSize;
@@ -117,6 +119,8 @@ public class ListenerParameters implements Cloneable {
 		this.attributes = Collections.emptySet();
 
 		this.rerun = DEFAULT_RETURN;
+
+		this.append = DEFAULT_RETURN;
 
 		this.asyncReporting = DEFAULT_ASYNC_REPORTING;
 		this.callbackReportingEnabled = DEFAULT_CALLBACK_REPORTING_ENABLED;
@@ -158,6 +162,9 @@ public class ListenerParameters implements Cloneable {
 		this.keystorePassword = properties.getProperty(KEYSTORE_PASSWORD);
 		this.rerun = properties.getPropertyAsBoolean(RERUN, DEFAULT_RETURN);
 		this.rerunOf = properties.getProperty(RERUN_OF);
+
+		this.append = properties.getPropertyAsBoolean(APPEND, DEFAULT_RETURN);
+		this.appendTo = properties.getProperty(APPEND_OF);
 
 		this.asyncReporting = properties.getPropertyAsBoolean(ASYNC_REPORTING, DEFAULT_ASYNC_REPORTING);
 		this.callbackReportingEnabled = properties.getPropertyAsBoolean(CALLBACK_REPORTING_ENABLED, DEFAULT_CALLBACK_REPORTING_ENABLED);
@@ -339,6 +346,10 @@ public class ListenerParameters implements Cloneable {
 		return rerun;
 	}
 
+	public boolean isAppend() {
+		return append;
+	}
+
 	public boolean isAsyncReporting() {
 		return asyncReporting;
 	}
@@ -365,6 +376,18 @@ public class ListenerParameters implements Cloneable {
 
 	public void setRerunOf(String rerunOf) {
 		this.rerunOf = rerunOf;
+	}
+
+	public void setAppend(boolean append) {
+		this.append = append;
+	}
+
+	public String getAppendTo() {
+		return appendTo;
+	}
+
+	public void setAppendTo(String appendTo) {
+		this.appendTo = appendTo;
 	}
 
 	public Integer getIoPoolSize() {
@@ -521,6 +544,8 @@ public class ListenerParameters implements Cloneable {
 		sb.append(", keystorePassword='").append(keystorePassword).append('\'');
 		sb.append(", rerun=").append(rerun);
 		sb.append(", rerunOf='").append(rerunOf).append('\'');
+		sb.append(", append=").append(append);
+		sb.append(", appendTo='").append(appendTo).append('\'');
 		sb.append(", asyncReporting=").append(asyncReporting);
 		sb.append(", ioPoolSize=").append(ioPoolSize);
 		sb.append(", callbackReportingEnabled=").append(callbackReportingEnabled);

--- a/src/main/java/com/epam/reportportal/service/ReportPortal.java
+++ b/src/main/java/com/epam/reportportal/service/ReportPortal.java
@@ -106,6 +106,15 @@ public class ReportPortal {
 			return Launch.NOOP_LAUNCH;
 		}
 
+		if (parameters.isAppend()) {
+			if (isNotBlank(parameters.getAppendTo())) {
+				return withLaunch(Maybe.just(parameters.getAppendTo()));
+			} else {
+				LOGGER.warn("Append to existing launch is enabled, but no append.to launch uuid is provided");
+				return Launch.NOOP_LAUNCH;
+			}
+		}
+
 		if (launchIdLock == null) {
 			// do not use multi-client mode
 			return new LaunchImpl(rpClient, parameters, rq, executor);

--- a/src/main/java/com/epam/reportportal/utils/properties/ListenerProperty.java
+++ b/src/main/java/com/epam/reportportal/utils/properties/ListenerProperty.java
@@ -42,6 +42,8 @@ public enum ListenerProperty {
     ENABLE("rp.enable", false),
     RERUN("rp.rerun", false),
     RERUN_OF("rp.rerun.of", false),
+    APPEND("rp.append", false),
+    APPEND_OF("rp.append.to", false),
     ASYNC_REPORTING("rp.reporting.async", false),
     CALLBACK_REPORTING_ENABLED("rp.reporting.callback", false),
     SKIPPED_AS_ISSUE("rp.skipped.issue", false),

--- a/src/test/java/com/epam/reportportal/listeners/ListenerParametersTest.java
+++ b/src/test/java/com/epam/reportportal/listeners/ListenerParametersTest.java
@@ -61,6 +61,15 @@ public class ListenerParametersTest {
 	}
 
 	@Test
+	public void testAppendKey() {
+		PropertiesLoader properties = PropertiesLoader.load("property-test/reportportal-append.properties");
+		ListenerParameters listenerParameters = new ListenerParameters(properties);
+
+		assertTrue(listenerParameters.isAppend());
+		assertEquals("launch_id", listenerParameters.getAppendTo());
+	}
+
+	@Test
 	public void parametersCloneTest() {
 		ListenerParameters params = TestUtils.STANDARD_PARAMETERS;
 		ListenerParameters paramsClone = params.clone();

--- a/src/test/java/com/epam/reportportal/service/ReportPortalTest.java
+++ b/src/test/java/com/epam/reportportal/service/ReportPortalTest.java
@@ -74,6 +74,31 @@ public class ReportPortalTest {
 	}
 
 	@Test
+	public void append_enabled_without_provided_append_to() {
+		ListenerParameters listenerParameters = new ListenerParameters();
+		listenerParameters.setBaseUrl("http://localhost");
+		listenerParameters.setEnable(true);
+		listenerParameters.setAppend(true);
+
+		ReportPortal rp = ReportPortal.builder().withParameters(listenerParameters).build();
+		Launch launch = rp.newLaunch(TestUtils.standardLaunchRequest(listenerParameters));
+		assertThat(launch, sameInstance(Launch.NOOP_LAUNCH));
+	}
+
+	@Test
+	public void append_enabled_with_provided_append_to() {
+		ListenerParameters listenerParameters = new ListenerParameters();
+		listenerParameters.setBaseUrl("http://localhost");
+		listenerParameters.setEnable(true);
+		listenerParameters.setAppend(true);
+		listenerParameters.setAppendTo(UUID.randomUUID().toString());
+
+		ReportPortal rp = ReportPortal.builder().withParameters(listenerParameters).build();
+		Launch launch = rp.newLaunch(TestUtils.standardLaunchRequest(listenerParameters));
+		assertThat(launch, not(sameInstance(Launch.NOOP_LAUNCH)));
+	}
+
+	@Test
 	public void proxyParamBypass() throws Exception {
 		String baseUrl = "http://example.com:8080";
 		ServerSocket server = SocketUtils.getServerSocketOnFreePort();

--- a/src/test/resources/property-test/reportportal-append.properties
+++ b/src/test/resources/property-test/reportportal-append.properties
@@ -1,0 +1,2 @@
+rp.append=true
+rp.append.to=launch_id


### PR DESCRIPTION
Hi,

I have situation, when I have paralelized jenkins jobs which run the same group (e.g. api tests), but runs them in paralel to shorten the duration of testing. I would like to report each parallel job to the one started launch in RP. I'm able to start/stop launch by Rest API, but I don't know how I can provide launch id to the agent?

Scenario:

    Start testing job:
    Start new launch by Rest API
    Start subjobs
    3a) Start sub-job1 with provided launch id and test results are published to the launch
    3b) Start sub-job2 with provided launch id and test results are published to the launch
    Finish started lauch by Rest API

When I use rerun option, launch is closed by each sub job and launch is marked as rerun. This is not exactly what I want.

The change enable to define:

rp.append=true
rp.append.of=launch_id

These changes are used by append functionality in agent-java-testNG (PR will be published soon) to be able to publish results from multiple separated executions (not multi-threaded, multiple parallel jobs in jenkins) into one launch.