### PR TITLE
Fix secondary launch log upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Ensure all logs are sent before JVM exit for secondary Launches, by @HardNorth
 
 ## [5.3.15]
 ### Fixed

--- a/src/main/java/com/epam/reportportal/aspect/StepNameUtils.java
+++ b/src/main/java/com/epam/reportportal/aspect/StepNameUtils.java
@@ -46,8 +46,7 @@ public class StepNameUtils {
 	 * @return step name
 	 */
 	@Nonnull
-	public static String getStepName(@Nonnull Step step, @Nonnull MethodSignature signature,
-			@Nonnull JoinPoint joinPoint) {
+	public static String getStepName(@Nonnull Step step, @Nonnull MethodSignature signature, @Nonnull JoinPoint joinPoint) {
 		String nameTemplate = step.value();
 		if (nameTemplate.trim().isEmpty()) {
 			return signature.getMethod().getName();
@@ -70,21 +69,14 @@ public class StepNameUtils {
 	public static String getStepName(@Nonnull String nameTemplate, @Nonnull TemplateConfiguration config,
 			@Nonnull MethodSignature signature, @Nonnull JoinPoint joinPoint) {
 		Map<String, Object> parametersMap = createParamsMapping(signature, joinPoint);
-		return TemplateProcessing.processTemplate(nameTemplate,
-				joinPoint.getThis(),
-				signature.getMethod(),
-				parametersMap,
-				config
-		);
+		return TemplateProcessing.processTemplate(nameTemplate, joinPoint.getThis(), signature.getMethod(), parametersMap, config);
 	}
 
 	@Nonnull
 	static Map<String, Object> createParamsMapping(@Nonnull MethodSignature signature, @Nonnull JoinPoint joinPoint) {
 		Object[] args = joinPoint.getArgs();
 		String[] parameterNames = signature.getParameterNames();
-		int paramsCount = Math.min(ofNullable(parameterNames).map(p -> p.length).orElse(0),
-				ofNullable(args).map(a -> a.length).orElse(0)
-		);
+		int paramsCount = Math.min(ofNullable(parameterNames).map(p -> p.length).orElse(0), ofNullable(args).map(a -> a.length).orElse(0));
 
 		Map<String, Object> paramsMapping = new HashMap<>();
 		for (int i = 0; i < paramsCount; i++) {

--- a/src/main/java/com/epam/reportportal/listeners/LogLevel.java
+++ b/src/main/java/com/epam/reportportal/listeners/LogLevel.java
@@ -20,5 +20,11 @@ package com.epam.reportportal.listeners;
  * All possible logging level supported by a backend.
  */
 public enum LogLevel {
-	ERROR, WARN, INFO, DEBUG, TRACE, FATAL, UNKNOWN
+	ERROR,
+	WARN,
+	INFO,
+	DEBUG,
+	TRACE,
+	FATAL,
+	UNKNOWN
 }

--- a/src/main/java/com/epam/reportportal/service/LaunchImpl.java
+++ b/src/main/java/com/epam/reportportal/service/LaunchImpl.java
@@ -343,12 +343,12 @@ public class LaunchImpl extends Launch {
 	 *
 	 * @param statistics whether to send analytics events for the launch
 	 * @return a {@link Maybe} that emits the launch UUID once available
-	 * @throws InternalReportPortalClientException if the executor has been shut down
 	 */
 	@Nonnull
 	protected Maybe<String> start(boolean statistics) {
 		if (getExecutor().isShutdown()) {
-			throw new InternalReportPortalClientException("Executor service is already shut down");
+			LOGGER.error("Unable to start Launch: executor service is already shut down. The data may be lost.");
+			return Maybe.empty();
 		}
 
 		ListenerParameters params = getParameters();
@@ -459,7 +459,8 @@ public class LaunchImpl extends Launch {
 	 */
 	public void finish(final FinishExecutionRQ request) {
 		if (getExecutor().isShutdown()) {
-			throw new InternalReportPortalClientException("Executor service is already shut down");
+			LOGGER.error("Unable to finish Launch: executor service is already shut down. The data may be lost.");
+			return;
 		}
 
 		// Close and re-create statistics service

--- a/src/main/java/com/epam/reportportal/service/LaunchImpl.java
+++ b/src/main/java/com/epam/reportportal/service/LaunchImpl.java
@@ -160,6 +160,17 @@ public class LaunchImpl extends Launch {
 		return ofNullable(client.getProjectSettings()).map(settings -> settings.subscribeOn(scheduler).cache()).orElse(Maybe.empty());
 	}
 
+	/**
+	 * Constructs a {@link LaunchImpl} that starts a new launch on first use and
+	 * configures a batched log emitter.
+	 *
+	 * @param reportPortalClient the client used to communicate with ReportPortal
+	 * @param parameters         the agent listener parameters
+	 * @param rq                 launch start request used to initialize the launch
+	 * @param executorService    executor used to schedule reactive operations
+	 * @param loggingSubscriber  subscriber which receives batched log upload results
+	 * @throws InternalReportPortalClientException if the provided executor is already shut down
+	 */
 	protected LaunchImpl(@Nonnull final ReportPortalClient reportPortalClient, @Nonnull final ListenerParameters parameters,
 			@Nonnull final StartLaunchRQ rq, @Nonnull final ExecutorService executorService,
 			@Nonnull final LoggingSubscriber loggingSubscriber) {
@@ -182,11 +193,29 @@ public class LaunchImpl extends Launch {
 		projectSettings = getProjectSettings(getClient(), getScheduler());
 	}
 
+	/**
+	 * Convenience constructor which uses a default {@link LoggingSubscriber} for batched log uploads.
+	 *
+	 * @param reportPortalClient the client used to communicate with ReportPortal
+	 * @param parameters         the agent listener parameters
+	 * @param rq                 launch start request used to initialize the launch
+	 * @param executorService    executor used to schedule reactive operations
+	 */
 	protected LaunchImpl(@Nonnull final ReportPortalClient reportPortalClient, @Nonnull final ListenerParameters parameters,
 			@Nonnull final StartLaunchRQ rq, @Nonnull final ExecutorService executorService) {
 		this(reportPortalClient, parameters, rq, executorService, new LoggingSubscriber());
 	}
 
+	/**
+	 * Constructs a {@link LaunchImpl} using an already created launch ID promise.
+	 * No new launch will be started by this instance.
+	 *
+	 * @param reportPortalClient the client used to communicate with ReportPortal
+	 * @param parameters         the agent listener parameters
+	 * @param launchMaybe        an existing launch ID promise to be used by this instance
+	 * @param executorService    executor used to schedule reactive operations
+	 * @throws InternalReportPortalClientException if the provided executor is already shut down
+	 */
 	protected LaunchImpl(@Nonnull final ReportPortalClient reportPortalClient, @Nonnull final ListenerParameters parameters,
 			@Nonnull final Maybe<String> launchMaybe, @Nonnull final ExecutorService executorService) {
 		super(reportPortalClient, parameters);
@@ -212,6 +241,13 @@ public class LaunchImpl extends Launch {
 		return result;
 	}
 
+	/**
+	 * Creates or reuses an RxJava {@link Scheduler} backed by the provided executor.
+	 * Ensures a single scheduler per executor instance.
+	 *
+	 * @param executorService the executor to back the scheduler
+	 * @return a scheduler mapped to the provided executor
+	 */
 	protected Scheduler createScheduler(ExecutorService executorService) {
 		return SCHEDULERS.computeIfAbsent(executorService, Schedulers::from);
 	}
@@ -245,6 +281,11 @@ public class LaunchImpl extends Launch {
 		return launch.get();
 	}
 
+	/**
+	 * Returns the statistics service responsible for sending analytics events.
+	 *
+	 * @return the current {@link StatisticsService}
+	 */
 	StatisticsService getStatisticsService() {
 		return statisticsService;
 	}
@@ -297,21 +338,12 @@ public class LaunchImpl extends Launch {
 	}
 
 	/**
-	 * Marks flow as completed
+	 * Starts the launch asynchronously on first subscription. Subsequent calls do
+	 * not start the launch again due to internal caching.
 	 *
-	 * @return {@link Completable}
-	 */
-	public Completable completeLogCompletables() {
-		Completable items = Completable.merge(logCompletables);
-		logCompletables.clear();
-		return items;
-	}
-
-	/**
-	 * Starts launch in ReportPortal. Does NOT start the same launch twice.
-	 *
-	 * @param statistics Send or not Launch statistics.
-	 * @return Launch ID promise.
+	 * @param statistics whether to send analytics events for the launch
+	 * @return a {@link Maybe} that emits the launch UUID once available
+	 * @throws InternalReportPortalClientException if the executor has been shut down
 	 */
 	@Nonnull
 	protected Maybe<String> start(boolean statistics) {
@@ -382,6 +414,12 @@ public class LaunchImpl extends Launch {
 		}
 	}
 
+	private Completable completeLogCompletables() {
+		Completable items = Completable.merge(logCompletables);
+		logCompletables.clear();
+		return items;
+	}
+
 	/**
 	 * Waits for completion of all test items including virtual ones and log emitters.
 	 * This method ensures all test results are properly reported to ReportPortal before the launch completes.
@@ -393,6 +431,11 @@ public class LaunchImpl extends Launch {
 		waitForCompletable(getLaunch().ignoreElement(), createVirtualItemCompletable(), itemCompletable, completeLogCompletables());
 	}
 
+	/**
+	 * Finalizes the batched log emitter ensuring the last batch is sent before
+	 * completing. Blocks within the configured reporting timeout while waiting for
+	 * the final batch to be processed.
+	 */
 	protected void completeLogEmitter() {
 		if (logEmitter.hasComplete()) {
 			return;
@@ -901,20 +944,41 @@ public class LaunchImpl extends Launch {
 		private volatile Maybe<String> parent;
 		private final List<Completable> children = new CopyOnWriteArrayList<>();
 
+		/**
+		 * Sets the parent item promise for this tree node.
+		 *
+		 * @param parent the parent item ID promise, may be {@code null} for a root
+		 * @return this instance for chaining
+		 */
 		public LaunchImpl.TreeItem withParent(@Nullable Maybe<String> parent) {
 			this.parent = parent;
 			return this;
 		}
 
+		/**
+		 * Adds a completion task representing a child operation to this node.
+		 *
+		 * @param completable the child completion task to add
+		 */
 		public void addToQueue(@Nonnull Completable completable) {
 			this.children.add(completable);
 		}
 
+		/**
+		 * Returns a snapshot list of child completion tasks.
+		 *
+		 * @return a new list containing this node's child completables
+		 */
 		@Nonnull
 		public List<Completable> getChildren() {
 			return new ArrayList<>(this.children);
 		}
 
+		/**
+		 * Returns the parent item ID promise or {@code null} if this is a root.
+		 *
+		 * @return the parent item ID promise or {@code null}
+		 */
 		@Nullable
 		public Maybe<String> getParent() {
 			return parent;
@@ -922,6 +986,13 @@ public class LaunchImpl extends Launch {
 	}
 
 	protected static class ComputationConcurrentHashMap extends ConcurrentHashMap<Maybe<String>, LaunchImpl.TreeItem> {
+		/**
+		 * Returns an existing tree item by key or creates and stores a new one
+		 * atomically if absent.
+		 *
+		 * @param key the key representing an item ID promise
+		 * @return the existing or newly created {@link LaunchImpl.TreeItem}
+		 */
 		public LaunchImpl.TreeItem getOrCompute(Maybe<String> key) {
 			return computeIfAbsent(key, k -> new LaunchImpl.TreeItem());
 		}

--- a/src/main/java/com/epam/reportportal/service/launch/PrimaryLaunch.java
+++ b/src/main/java/com/epam/reportportal/service/launch/PrimaryLaunch.java
@@ -50,7 +50,6 @@ public class PrimaryLaunch extends AbstractJoinedLaunch {
 	 */
 	@Override
 	public void finish(final FinishExecutionRQ request) {
-		stopRunning();
 		Callable<Boolean> finishCondition = new SecondaryLaunchFinishCondition(lock, uuid);
 		Boolean finished = Boolean.FALSE;
 		// If there was launch number change (finished == false) we will wait more.
@@ -60,9 +59,10 @@ public class PrimaryLaunch extends AbstractJoinedLaunch {
 					.pollingEvery(1, TimeUnit.SECONDS);
 			finished = waiter.till(finishCondition);
 		}
-		lock.finishInstanceUuid(uuid);
 		FinishExecutionRQ rq = clonePojo(request, FinishExecutionRQ.class);
 		rq.setEndTime(Calendar.getInstance().getTime());
 		super.finish(rq);
+		stopRunning();
+		lock.finishInstanceUuid(uuid);
 	}
 }

--- a/src/main/java/com/epam/reportportal/service/launch/PrimaryLaunch.java
+++ b/src/main/java/com/epam/reportportal/service/launch/PrimaryLaunch.java
@@ -53,7 +53,6 @@ public class PrimaryLaunch extends AbstractJoinedLaunch {
 		Callable<Boolean> finishCondition = new SecondaryLaunchFinishCondition(lock, uuid);
 		Boolean finished = Boolean.FALSE;
 		// If there was launch number change (finished == false) we will wait more.
-		// Only if
 		while (finished != Boolean.TRUE && finished != null) {
 			Waiter waiter = new Waiter("Wait for all launches end").duration(getParameters().getClientJoinTimeout(), TimeUnit.MILLISECONDS)
 					.pollingEvery(1, TimeUnit.SECONDS);

--- a/src/main/java/com/epam/reportportal/service/logs/LogBatchingFlowable.java
+++ b/src/main/java/com/epam/reportportal/service/logs/LogBatchingFlowable.java
@@ -20,7 +20,6 @@ import com.epam.reportportal.listeners.ListenerParameters;
 import com.epam.ta.reportportal.ws.model.log.SaveLogRQ;
 import io.reactivex.Flowable;
 import io.reactivex.internal.fuseable.HasUpstreamPublisher;
-import io.reactivex.subscribers.SerializedSubscriber;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 

--- a/src/main/java/com/epam/reportportal/utils/AttributeParser.java
+++ b/src/main/java/com/epam/reportportal/utils/AttributeParser.java
@@ -148,10 +148,7 @@ public class AttributeParser {
 	@Nonnull
 	public static List<ItemAttributesRQ> createItemAttributes(@Nullable String key, @Nullable String[] values) {
 		if (values != null && values.length > 0) {
-			return Arrays.stream(values)
-					.filter(StringUtils::isNotBlank)
-					.map(v -> createItemAttribute(key, v))
-					.collect(Collectors.toList());
+			return Arrays.stream(values).filter(StringUtils::isNotBlank).map(v -> createItemAttribute(key, v)).collect(Collectors.toList());
 		}
 		return Collections.emptyList();
 	}

--- a/src/main/java/com/epam/reportportal/utils/ClientIdProvider.java
+++ b/src/main/java/com/epam/reportportal/utils/ClientIdProvider.java
@@ -34,7 +34,6 @@ public class ClientIdProvider {
 		throw new IllegalStateException("Static only class");
 	}
 
-
 	private static final String CLIENT_ID_PROPERTY = "client.id";
 	public static final Path RP_PROPERTIES_FILE_PATH = Paths.get(System.getProperty("user.home"), ".rp", "rp.properties");
 

--- a/src/main/java/com/epam/reportportal/utils/ParameterUtils.java
+++ b/src/main/java/com/epam/reportportal/utils/ParameterUtils.java
@@ -48,7 +48,7 @@ public class ParameterUtils {
 	 * Read all parameters from a method or a constructor and converts in into a list of {@link ParameterResource}.
 	 * Respects {@link ParameterKey} annotation.
 	 *
-	 * @param <T> parameter values type
+	 * @param <T>             parameter values type
 	 * @param method          a method to read parameters
 	 * @param parameterValues a source of parameter values
 	 * @return a list of parameter POJOs with fulfilled name and value.
@@ -119,13 +119,14 @@ public class ParameterUtils {
 	 * Read all parameters from a method or a constructor and converts in into a list of {@link ParameterResource}.
 	 * Respects {@link ParameterKey} annotation.
 	 *
-	 * @param <T> parameter values type
+	 * @param <T>        parameter values type
 	 * @param codeRef    a method reference to read parameters
 	 * @param parameters a source of parameter values and parameter names if not set by {@link ParameterKey} annotation
 	 * @return a list of parameter POJOs with fulfilled name and value.
 	 */
 	@Nonnull
-	public static <T> List<ParameterResource> getParameters(@Nullable final String codeRef, @Nullable final List<Pair<String, T>> parameters) {
+	public static <T> List<ParameterResource> getParameters(@Nullable final String codeRef,
+			@Nullable final List<Pair<String, T>> parameters) {
 		Optional<List<Object>> paramValues = ofNullable(parameters).map(args -> args.stream()
 				.map(a -> (Object) a.getValue())
 				.collect(Collectors.toList()));
@@ -145,9 +146,10 @@ public class ParameterUtils {
 					testStepClass = Optional.empty();
 				}
 			}
-			return testStepClass.flatMap(cl -> Stream.concat(Arrays.stream(cl.getDeclaredMethods()),
-					Arrays.stream(cl.getDeclaredConstructors())
-			)
+			return testStepClass.flatMap(cl -> Stream.concat(
+							Arrays.stream(cl.getDeclaredMethods()),
+							Arrays.stream(cl.getDeclaredConstructors())
+					)
 					.filter(m -> methodName.equals(m.getName()) || cr.equals(m.getName()))
 					.filter(m -> m.getParameterCount() == paramValues.map(List::size).orElse(0))
 					.findAny());

--- a/src/main/java/com/epam/reportportal/utils/TestCaseIdUtils.java
+++ b/src/main/java/com/epam/reportportal/utils/TestCaseIdUtils.java
@@ -80,8 +80,7 @@ public class TestCaseIdUtils {
 		Annotation[][] parameterAnnotations = executable.getParameterAnnotations();
 		List<Integer> keys = new ArrayList<>();
 		for (int paramIndex = 0; paramIndex < parameterAnnotations.length; paramIndex++) {
-			for (int annotationIndex = 0; annotationIndex < parameterAnnotations[paramIndex].length;
-			     annotationIndex++) {
+			for (int annotationIndex = 0; annotationIndex < parameterAnnotations[paramIndex].length; annotationIndex++) {
 				Annotation testCaseIdAnnotation = parameterAnnotations[paramIndex][annotationIndex];
 				if (testCaseIdAnnotation.annotationType() == TestCaseIdKey.class) {
 					keys.add(paramIndex);
@@ -108,7 +107,7 @@ public class TestCaseIdUtils {
 	 */
 	@Nullable
 	public static <T> TestCaseIdEntry getTestCaseId(@Nullable TestCaseId annotation, @Nullable Executable executable,
-	                                                @Nullable List<T> parameters) {
+			@Nullable List<T> parameters) {
 		return getTestCaseId(annotation, executable, null, parameters);
 	}
 
@@ -124,7 +123,7 @@ public class TestCaseIdUtils {
 	 */
 	@Nullable
 	public static <T> TestCaseIdEntry getTestCaseId(@Nullable TestCaseId annotation, @Nullable Executable executable,
-	                                                @Nullable String codRef, @Nullable List<T> parameters) {
+			@Nullable String codRef, @Nullable List<T> parameters) {
 		return getTestCaseId(annotation, executable, codRef, parameters, null);
 	}
 
@@ -141,8 +140,7 @@ public class TestCaseIdUtils {
 	 */
 	@Nullable
 	public static <T> TestCaseIdEntry getTestCaseId(@Nullable TestCaseId annotation, @Nullable Executable executable,
-	                                                @Nullable String codRef, @Nullable List<T> parameters,
-	                                                @Nullable Object testInstance) {
+			@Nullable String codRef, @Nullable List<T> parameters, @Nullable Object testInstance) {
 		if (annotation != null) {
 			if (annotation.value().isEmpty()) {
 				if (annotation.parametrized()) {
@@ -150,29 +148,20 @@ public class TestCaseIdUtils {
 							.orElse(ofNullable(codRef).map(c -> getTestCaseId(c, parameters))
 									.orElse(getTestCaseId(executable, parameters)));
 				} else {
-					return ofNullable(codRef).map(c -> getTestCaseId(c, parameters))
-							.orElse(getTestCaseId(executable, parameters));
+					return ofNullable(codRef).map(c -> getTestCaseId(c, parameters)).orElse(getTestCaseId(executable, parameters));
 				}
 			} else {
 				String idTemplate = annotation.value();
 				TemplateConfiguration templateConfig = new TemplateConfiguration(annotation.config());
 				Map<String, Object> parametersMap = new HashMap<>();
-				ofNullable(parameters).ifPresent(params -> IntStream.range(0,
-								params.size()
-						)
+				ofNullable(parameters).ifPresent(params -> IntStream.range(0, params.size())
 						.boxed()
 						.forEach(i -> parametersMap.put(i.toString(), params.get(i))));
-				String id = TemplateProcessing.processTemplate(idTemplate,
-						testInstance,
-						executable,
-						parametersMap,
-						templateConfig
-				);
+				String id = TemplateProcessing.processTemplate(idTemplate, testInstance, executable, parametersMap, templateConfig);
 
 				if (annotation.parametrized()) {
 					String resultParameters = getParametersForTestCaseId(executable, parameters);
-					return ofNullable(resultParameters).map(p -> new TestCaseIdEntry(
-									id + (p.startsWith("[") ? p : "[" + p + "]")))
+					return ofNullable(resultParameters).map(p -> new TestCaseIdEntry(id + (p.startsWith("[") ? p : "[" + p + "]")))
 							.orElse(ofNullable(codRef).map(c -> getTestCaseId(c, parameters))
 									.orElse(getTestCaseId(executable, parameters)));
 				} else {
@@ -193,8 +182,7 @@ public class TestCaseIdUtils {
 	 */
 	@Nullable
 	public static <T> TestCaseIdEntry getTestCaseId(@Nullable Executable executable, @Nullable List<T> parameters) {
-		return ofNullable(executable).map(m -> getTestCaseId(getCodeRef(m), parameters))
-				.orElse(getTestCaseId(parameters));
+		return ofNullable(executable).map(m -> getTestCaseId(getCodeRef(m), parameters)).orElse(getTestCaseId(parameters));
 	}
 
 	/**
@@ -207,8 +195,7 @@ public class TestCaseIdUtils {
 	 */
 	@Nullable
 	public static <T> TestCaseIdEntry getTestCaseId(@Nullable String codeRef, @Nullable List<T> parameters) {
-		return ofNullable(codeRef).map(r -> new TestCaseIdEntry(
-						codeRef + ofNullable(parameters).map(TRANSFORM_PARAMETERS).orElse("")))
+		return ofNullable(codeRef).map(r -> new TestCaseIdEntry(codeRef + ofNullable(parameters).map(TRANSFORM_PARAMETERS).orElse("")))
 				.orElse(getTestCaseId(parameters));
 	}
 

--- a/src/main/java/com/epam/reportportal/utils/Waiter.java
+++ b/src/main/java/com/epam/reportportal/utils/Waiter.java
@@ -119,10 +119,10 @@ public class Waiter {
 	 * If the thread is interrupted, a warning is logged and {@code null} is returned.
 	 *
 	 * @param waitFor a callable that is evaluated repeatedly until it returns a non-null result
-	 * @param <T> type of the result supplied by the callable
+	 * @param <T>     type of the result supplied by the callable
 	 * @return the first non-null result returned by the callable; {@code null} on timeout/interruption when not configured to fail
 	 * @throws InternalReportPortalClientException if an unexpected exception occurs in the callable
-	 *                                            or if timeout occurs and {@link #timeoutFail()} was configured
+	 *                                             or if timeout occurs and {@link #timeoutFail()} was configured
 	 */
 	public <T> T till(Callable<T> waitFor) {
 		long triesLong = durationNs / pollingNs;

--- a/src/main/java/com/epam/reportportal/utils/files/ImageConverter.java
+++ b/src/main/java/com/epam/reportportal/utils/files/ImageConverter.java
@@ -54,7 +54,8 @@ public class ImageConverter {
 	 */
 	public static TypeAwareByteSource convert(ByteSource source) throws IOException {
 		BufferedImage image = ImageIO.read(source.openBufferedStream());
-		final BufferedImage blackAndWhiteImage = new BufferedImage(image.getWidth(null),
+		final BufferedImage blackAndWhiteImage = new BufferedImage(
+				image.getWidth(null),
 				image.getHeight(null),
 				BufferedImage.TYPE_BYTE_GRAY
 		);

--- a/src/main/java/com/epam/reportportal/utils/files/ImageConverter.java
+++ b/src/main/java/com/epam/reportportal/utils/files/ImageConverter.java
@@ -53,16 +53,21 @@ public class ImageConverter {
 	 * @throws IOException In case of IO exception
 	 */
 	public static TypeAwareByteSource convert(ByteSource source) throws IOException {
-		BufferedImage image = ImageIO.read(source.openBufferedStream());
-		final BufferedImage blackAndWhiteImage = new BufferedImage(
-				image.getWidth(null),
-				image.getHeight(null),
-				BufferedImage.TYPE_BYTE_GRAY
-		);
-		final Graphics2D graphics2D = (Graphics2D) blackAndWhiteImage.getGraphics();
-		graphics2D.drawImage(image, 0, 0, null);
-		graphics2D.dispose();
-		return convertToInputStream(blackAndWhiteImage);
+		try (java.io.InputStream in = source.openBufferedStream()) {
+			BufferedImage image = ImageIO.read(in);
+			if (image == null) {
+				throw new IOException("Unsupported or unreadable image content");
+			}
+			final BufferedImage blackAndWhiteImage = new BufferedImage(
+					image.getWidth(null),
+					image.getHeight(null),
+					BufferedImage.TYPE_BYTE_GRAY
+			);
+			final Graphics2D graphics2D = (Graphics2D) blackAndWhiteImage.getGraphics();
+			graphics2D.drawImage(image, 0, 0, null);
+			graphics2D.dispose();
+			return convertToInputStream(blackAndWhiteImage);
+		}
 	}
 
 	/**

--- a/src/main/java/com/epam/reportportal/utils/formatting/ExceptionUtils.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/ExceptionUtils.java
@@ -41,15 +41,15 @@ public class ExceptionUtils {
 	 */
 	public static String getStackTrace(Throwable throwable, Throwable baseThrowable, boolean preserveCause) {
 		String[] mainFrames = org.apache.commons.lang3.exception.ExceptionUtils.getStackFrames(throwable);
-		Set<String> baseFrames = Arrays.stream(org.apache.commons.lang3.exception.ExceptionUtils.getStackFrames(baseThrowable)).collect(
-				Collectors.toSet());
+		Set<String> baseFrames = Arrays.stream(org.apache.commons.lang3.exception.ExceptionUtils.getStackFrames(baseThrowable))
+				.collect(Collectors.toSet());
 		StringBuilder sb = new StringBuilder();
 		if (mainFrames.length > 0) {
 			sb.append(mainFrames[0]).append(LINE_DELIMITER);
 			boolean skipping = false;
 			for (int i = 1; i < mainFrames.length; i++) {
 				String frame = mainFrames[i];
-				if(baseFrames.contains(frame) && (!frame.startsWith("Caused by:") || !preserveCause)) {
+				if (baseFrames.contains(frame) && (!frame.startsWith("Caused by:") || !preserveCause)) {
 					if (!skipping) {
 						sb.append(SKIP_TRACE_MARKER);
 						skipping = true;
@@ -66,7 +66,7 @@ public class ExceptionUtils {
 	/**
 	 * Get stack trace of the throwable excluding the stack trace of the base throwable.
 	 *
-	 * @param throwable Throwable to get stack trace from
+	 * @param throwable     Throwable to get stack trace from
 	 * @param baseThrowable Throwable to exclude stack trace from
 	 * @return Formatted stack trace
 	 */

--- a/src/main/java/com/epam/reportportal/utils/formatting/MarkdownUtils.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/MarkdownUtils.java
@@ -89,10 +89,7 @@ public class MarkdownUtils {
 		int tableColNum = table.stream().mapToInt(List::size).max().orElse(-1);
 		List<Iterator<T>> iterList = table.stream().map(List::iterator).collect(Collectors.toList());
 		return IntStream.range(0, tableColNum)
-				.mapToObj(n -> iterList.stream()
-						.filter(Iterator::hasNext)
-						.map(Iterator::next)
-						.collect(Collectors.toList()))
+				.mapToObj(n -> iterList.stream().filter(Iterator::hasNext).map(Iterator::next).collect(Collectors.toList()))
 				.collect(Collectors.toList());
 	}
 
@@ -136,7 +133,7 @@ public class MarkdownUtils {
 		List<Integer> colSizes = calculateColSizes(table);
 		boolean transpose = colSizes.size() > table.size() && calculateTableSize(colSizes) > maxTableSize;
 		List<List<String>> printTable = transpose ? transposeTable(table) : table;
-		if(transpose) {
+		if (transpose) {
 			colSizes = calculateColSizes(printTable);
 		}
 		colSizes = adjustColSizes(colSizes, maxTableSize);

--- a/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateConfiguration.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateConfiguration.java
@@ -78,11 +78,10 @@ public class TemplateConfiguration {
 			return false;
 		}
 		TemplateConfiguration that = (TemplateConfiguration) o;
-		return className.equals(that.className) && classRef.equals(that.classRef) && methodName.equals(that.methodName)
-				&& selfName.equals(that.selfName) && fieldDelimiter.equals(that.fieldDelimiter) && iterableStart.equals(
-				that.iterableStart) && iterableEnd.equals(that.iterableEnd)
-				&& iterableDelimiter.equals(that.iterableDelimiter) && arrayStart.equals(that.arrayStart)
-				&& arrayEnd.equals(that.arrayEnd) && arrayDelimiter.equals(that.arrayDelimiter);
+		return className.equals(that.className) && classRef.equals(that.classRef) && methodName.equals(that.methodName) && selfName.equals(
+				that.selfName) && fieldDelimiter.equals(that.fieldDelimiter) && iterableStart.equals(that.iterableStart)
+				&& iterableEnd.equals(that.iterableEnd) && iterableDelimiter.equals(that.iterableDelimiter)
+				&& arrayStart.equals(that.arrayStart) && arrayEnd.equals(that.arrayEnd) && arrayDelimiter.equals(that.arrayDelimiter);
 	}
 
 	@Override

--- a/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
@@ -151,7 +151,7 @@ public class TemplateProcessing {
 				String parameters = field.substring(methodCallStartIndex + 1, field.length() - 1);
 				if (!parameters.isEmpty()) {
 					LOGGER.warn("Method parameters are not supported. Method: {} Parameters: {}. Ignoring the call.", method, parameters);
-					return Arrays.stream(fields).collect(Collectors.joining(templateConfig.getFieldDelimiter()));
+					return String.join(templateConfig.getFieldDelimiter(), fields);
 				}
 				object = Accessible.on(object).method(method).invoke();
 			} else {

--- a/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
@@ -24,13 +24,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Executable;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 

--- a/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
@@ -103,7 +103,7 @@ public class TemplateProcessing {
 		try {
 			return retrieveValue(templateConfig, 1, fields, param);
 		} catch (Throwable e) {
-			LOGGER.error("Unable to parse: {}", templatePart);
+			LOGGER.error("Unable to parse: {}", templatePart, e);
 			return null;
 		}
 	}

--- a/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
@@ -150,11 +150,7 @@ public class TemplateProcessing {
 				String method = field.substring(0, methodCallStartIndex);
 				String parameters = field.substring(methodCallStartIndex + 1, field.length() - 1);
 				if (!parameters.isEmpty()) {
-					LOGGER.warn(
-							"Method parameters are not supported. Method: {} Parameters: {}. Ignoring the call.",
-							method,
-							parameters
-					);
+					LOGGER.warn("Method parameters are not supported. Method: {} Parameters: {}. Ignoring the call.", method, parameters);
 					return Arrays.stream(fields).collect(Collectors.joining(templateConfig.getFieldDelimiter()));
 				}
 				object = Accessible.on(object).method(method).invoke();

--- a/src/main/java/com/epam/reportportal/utils/http/ClientUtils.java
+++ b/src/main/java/com/epam/reportportal/utils/http/ClientUtils.java
@@ -43,8 +43,7 @@ public class ClientUtils {
 	}
 
 	@Nonnull
-	public static OkHttpClient.Builder setupProxy(@Nonnull OkHttpClient.Builder builder,
-	                                              @Nonnull ListenerParameters parameters) {
+	public static OkHttpClient.Builder setupProxy(@Nonnull OkHttpClient.Builder builder, @Nonnull ListenerParameters parameters) {
 		String proxyStr = parameters.getProxyUrl();
 		if (isBlank(proxyStr)) {
 			return builder;
@@ -52,19 +51,15 @@ public class ClientUtils {
 		try {
 			URL proxyUrl = new URL(proxyStr);
 			int port = proxyUrl.getPort();
-			builder.proxy(new Proxy(Proxy.Type.HTTP,
-					InetSocketAddress.createUnresolved(
-							proxyUrl.getHost(),
-							port >= 0 ? port : proxyUrl.getDefaultPort()
-					)
+			builder.proxy(new Proxy(
+					Proxy.Type.HTTP,
+					InetSocketAddress.createUnresolved(proxyUrl.getHost(), port >= 0 ? port : proxyUrl.getDefaultPort())
 			));
 			String proxyUser = parameters.getProxyUser();
 			if (isNotBlank(proxyUser)) {
 				builder.proxyAuthenticator((route, response) -> {
-					String credential = Credentials.basic(proxyUser, parameters.getProxyPassword(),
-							StandardCharsets.UTF_8);
-					return response.request().newBuilder().header("Proxy-Authorization", credential)
-							.build();
+					String credential = Credentials.basic(proxyUser, parameters.getProxyPassword(), StandardCharsets.UTF_8);
+					return response.request().newBuilder().header("Proxy-Authorization", credential).build();
 				});
 			}
 		} catch (MalformedURLException e) {

--- a/src/main/java/com/epam/reportportal/utils/http/HttpRequestUtils.java
+++ b/src/main/java/com/epam/reportportal/utils/http/HttpRequestUtils.java
@@ -18,13 +18,13 @@ package com.epam.reportportal.utils.http;
 
 import com.epam.reportportal.exception.InternalReportPortalClientException;
 import com.epam.reportportal.utils.MimeTypeDetector;
+import com.epam.reportportal.utils.files.ByteSource;
 import com.epam.ta.reportportal.ws.model.Constants;
 import com.epam.ta.reportportal.ws.model.log.SaveLogRQ;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.epam.reportportal.utils.files.ByteSource;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import org.slf4j.Logger;
@@ -61,10 +61,11 @@ public class HttpRequestUtils {
 	public static List<MultipartBody.Part> buildLogMultiPartRequest(List<SaveLogRQ> rqs) {
 		List<MultipartBody.Part> result = new ArrayList<>();
 		try {
-			result.add(MultipartBody.Part.createFormData(Constants.LOG_REQUEST_JSON_PART,
-					null,
+			result.add(MultipartBody.Part.createFormData(
+					Constants.LOG_REQUEST_JSON_PART, null,
 					// Deprecated method call left here till the very end for backward compatibility
-					RequestBody.create(okhttp3.MediaType.get("application/json; charset=utf-8"),
+					RequestBody.create(
+							okhttp3.MediaType.get("application/json; charset=utf-8"),
 							MAPPER.writerFor(new TypeReference<List<SaveLogRQ>>() {
 							}).writeValueAsString(rqs)
 					)
@@ -85,8 +86,8 @@ public class HttpRequestUtils {
 					LOGGER.error("Unable to parse content media type, default value was used: " + DEFAULT_TYPE, e);
 					type = okhttp3.MediaType.get(DEFAULT_TYPE);
 				}
-				result.add(MultipartBody.Part.createFormData(Constants.LOG_REQUEST_BINARY_PART,
-						file.getName(),
+				result.add(MultipartBody.Part.createFormData(
+						Constants.LOG_REQUEST_BINARY_PART, file.getName(),
 						// Deprecated method call left here till the very end for backward compatibility
 						RequestBody.create(type, file.getContent())
 				));

--- a/src/main/java/com/epam/reportportal/utils/properties/OutputTypes.java
+++ b/src/main/java/com/epam/reportportal/utils/properties/OutputTypes.java
@@ -19,7 +19,8 @@ package com.epam.reportportal.utils.properties;
 import java.io.PrintStream;
 
 public enum OutputTypes {
-	STDOUT(System.out), STDERR(System.err);
+	STDOUT(System.out),
+	STDERR(System.err);
 
 	private final PrintStream out;
 

--- a/src/main/java/com/epam/reportportal/utils/properties/PropertiesLoader.java
+++ b/src/main/java/com/epam/reportportal/utils/properties/PropertiesLoader.java
@@ -91,8 +91,8 @@ public class PropertiesLoader {
 	 */
 	public static String getPropertyFilePath() {
 		return ofNullable(normalizeOverrides(System.getProperties()).get(PROPERTIES_PATH_PROPERTY)).filter(StringUtils::isNotBlank)
-				.orElseGet(() -> ofNullable(normalizeOverrides(System.getenv()).get(PROPERTIES_PATH_PROPERTY)).filter(
-						StringUtils::isNotBlank).orElse(INNER_PATH));
+				.orElseGet(() -> ofNullable(normalizeOverrides(System.getenv()).get(PROPERTIES_PATH_PROPERTY)).filter(StringUtils::isNotBlank)
+						.orElse(INNER_PATH));
 	}
 
 	/**
@@ -197,9 +197,7 @@ public class PropertiesLoader {
 	 */
 	private static Map<String, String> normalizeOverrides(Map<?, ?> overrides) {
 		return overrides.entrySet().stream().collect(Collectors.toMap(
-				e -> e.getKey().toString().toLowerCase().replace('_', '.'),
-				e -> e.getValue().toString(),
-				(original, duplicate) -> {
+				e -> e.getKey().toString().toLowerCase().replace('_', '.'), e -> e.getValue().toString(), (original, duplicate) -> {
 					LOGGER.warn("Duplicate key found in property overrides.");
 					return original;
 				}
@@ -225,10 +223,7 @@ public class PropertiesLoader {
 		Map<String, String> overridesNormalized = normalizeOverrides(overrides);
 		for (ListenerProperty listenerProperty : values()) {
 			if (overridesNormalized.get(listenerProperty.getPropertyName()) != null) {
-				source.setProperty(
-						listenerProperty.getPropertyName(),
-						overridesNormalized.get(listenerProperty.getPropertyName())
-				);
+				source.setProperty(listenerProperty.getPropertyName(), overridesNormalized.get(listenerProperty.getPropertyName()));
 			}
 		}
 	}
@@ -244,8 +239,7 @@ public class PropertiesLoader {
 	}
 
 	private static Optional<URL> getResource(String resourceName) {
-		ClassLoader loader = ofNullable(Thread.currentThread()
-				.getContextClassLoader()).orElse(PropertiesLoader.class.getClassLoader());
+		ClassLoader loader = ofNullable(Thread.currentThread().getContextClassLoader()).orElse(PropertiesLoader.class.getClassLoader());
 		return ofNullable(loader.getResource(resourceName));
 	}
 }

--- a/src/test/java/com/epam/reportportal/service/step/ManualNestedStepTest.java
+++ b/src/test/java/com/epam/reportportal/service/step/ManualNestedStepTest.java
@@ -297,6 +297,7 @@ public class ManualNestedStepTest {
 	@SuppressWarnings({ "unchecked" })
 	public void verify_passed_actions_nested_step() {
 		mockNestedSteps(client, nestedStepPairs.get(0));
+		simulateFinishLaunchResponse(client);
 		mockBatchLogging(client);
 		String stepName = "verify_passed_actions_nested_step";
 		String returnValue = "return value";
@@ -332,9 +333,7 @@ public class ManualNestedStepTest {
 				.map(e -> Pair.of(e.getLevel(), e.getMessage()))
 				.collect(Collectors.toList());
 		assertThat(logRequests, hasSize(1));
-		Pair<String, String> log = logRequests.get(0);
-		assertThat(log.getKey(), equalTo(LogLevel.DEBUG.name()));
-		assertThat(log.getValue(), equalTo(logMessage));
+		assertThat(logRequests, hasItem(equalTo(Pair.of(LogLevel.DEBUG.name(), logMessage))));
 	}
 
 	@Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable launch finalization and log flushing so batched logs are sent before JVM exit; finish flow reordered and more tolerant of executor shutdowns.

* **Documentation**
  * CHANGELOG updated to note guaranteed log sending before JVM exit for secondary launches.

* **Tests**
  * Tests adapted to the updated finish and log-flush behavior.

* **Style**
  * Widespread formatting and minor cleanup with no behavioral changes.

* **Reliability**
  * Image handling now validates unreadable content and surfaces a clear I/O error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->