### PR TITLE
fix: escape closing brace in TemplateProcessing regex for Android ICU compatibility

### DIFF
--- a/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
+++ b/src/main/java/com/epam/reportportal/utils/formatting/templating/TemplateProcessing.java
@@ -40,7 +40,7 @@ public class TemplateProcessing {
 
 	public static final String NULL_VALUE = "NULL";
 
-	private static final Pattern TEMPLATE_GROUP = Pattern.compile("\\{([\\w$]+(\\.[\\w$]+)*)}");
+	private static final Pattern TEMPLATE_GROUP = Pattern.compile("\\{([\\w$]+(\\.[\\w$]+)*)\\}");
 
 	private TemplateProcessing() {
 		throw new IllegalStateException("Static only class");


### PR DESCRIPTION
## Summary

Escapes the closing `}` in the `TEMPLATE_GROUP` regex in `TemplateProcessing.java` to fix a `PatternSyntaxException` on Android.

## Problem

The regex `\{([\w$]+(\.[\w$]+)*)}` has an unescaped `}`. Java's `Pattern` on JVM is lenient and accepts this, but Android's ICU regex engine (`com.android.icu.util.regex.PatternNative`) is strict and rejects it at index 22.

Because this regex is compiled in a static initializer, the `PatternSyntaxException` becomes a permanent `ExceptionInInitializerError` — every subsequent call to `LaunchImpl.startTestItem()` via `applyNameFormat()` fails for the remainder of the JVM lifetime.

## Fix

One-character change: `)}` → `)\}`

`\}` is valid on both standard JVM and Android ICU — no behavioural change for non-Android consumers. All existing `TemplateProcessingTest` tests pass.

Fixes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template placeholder matching pattern for enhanced accuracy and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->